### PR TITLE
style: use '/usr/bin/env' as shebang

### DIFF
--- a/Linux/bashls.sh
+++ b/Linux/bashls.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 npm i -g bash-language-server

--- a/Linux/clangd.sh
+++ b/Linux/clangd.sh
@@ -1,1 +1,1 @@
-#!/bin/bash
+#!/usr/bin/env bash

--- a/Linux/cmake.sh
+++ b/Linux/cmake.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 pip install cmake-language-server

--- a/Linux/cssls.sh
+++ b/Linux/cssls.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 npm install -g vscode-css-languageserver-bin

--- a/Linux/docker.sh
+++ b/Linux/docker.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 npm i -g dockerfile-language-server-nodejs

--- a/Linux/elmls.sh
+++ b/Linux/elmls.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 npm install -g elm elm-test elm-format @elm-tooling/elm-language-server

--- a/Linux/html.sh
+++ b/Linux/html.sh
@@ -1,2 +1,2 @@
-#!bin/bash
+#!/usr/bin/env bash
 npm install -g vscode-html-languageserver-bin

--- a/Linux/intelephense.sh
+++ b/Linux/intelephense.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 npm i -g intelephense

--- a/Linux/jsonls.sh
+++ b/Linux/jsonls.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 npm install -g vscode-json-languageserver

--- a/Linux/purescriptls.sh
+++ b/Linux/purescriptls.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 npm install -g purescript-language-server

--- a/Linux/pyls.sh
+++ b/Linux/pyls.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 pip install python-language-server

--- a/Linux/rust.sh
+++ b/Linux/rust.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [[ -f ~/.local/bin/rust-analyzer ]]
 then
   rm -rf ~/.local/bin/rust-analyzer

--- a/Linux/svelte.sh
+++ b/Linux/svelte.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 npm install -g svelte-language-server

--- a/Linux/vuels.sh
+++ b/Linux/vuels.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 npm install -g vls

--- a/Linux/yamlls.sh
+++ b/Linux/yamlls.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 npm install -g yaml-language-server


### PR DESCRIPTION
Hi. I think it's better to use '/usr/bin/env NAME' as shebang as explained on [this](https://unix.stackexchange.com/questions/29608/why-is-it-better-to-use-usr-bin-env-name-instead-of-path-to-name-as-my)